### PR TITLE
Ensure toast still fits on screen after rotation

### DIFF
--- a/Toast/Toast/Toast+UIView.m
+++ b/Toast/Toast/Toast+UIView.m
@@ -257,6 +257,11 @@ static const NSString * CSToastActivityViewKey  = @"CSToastActivityViewKey";
         
         // size the message label according to the length of the text
         CGSize maxSizeMessage = CGSizeMake((self.bounds.size.width * CSToastMaxWidth) - imageWidth, self.bounds.size.height * CSToastMaxHeight);
+        
+        //make sure that if we rotate the message will still fit on the screen
+        CGFloat rotatedMaxMessageWidth = (self.bounds.size.height * CSToastMaxWidth) - imageWidth;
+        if (maxSizeMessage.width > rotatedMaxMessageWidth) maxSizeMessage.width = rotatedMaxMessageWidth;
+        
         CGSize expectedSizeMessage = [message sizeWithFont:messageLabel.font constrainedToSize:maxSizeMessage lineBreakMode:messageLabel.lineBreakMode]; 
         messageLabel.frame = CGRectMake(0.0, 0.0, expectedSizeMessage.width, expectedSizeMessage.height);
     }


### PR DESCRIPTION
Currently, if you rotate your device from landscape to portrait with a toast with a long message, it won't fit on screen. This fix will make sure it does, and on top of that it will look exactly as if it was generated in the new position. This should at the very least be an option I feel.
