### PR TITLE
explicitly require ARC so Toast doesn't leak

### DIFF
--- a/Toast.podspec
+++ b/Toast.podspec
@@ -9,4 +9,5 @@ Pod::Spec.new do |s|
   s.platform     = :ios
   s.source_files = 'Toast/Toast'   
   s.framework    = 'QuartzCore'
+  requires_arc   = true
 end


### PR DESCRIPTION
I noticed when running "Analyze" in xcode on one of my projects that all Toast's views seem to be leaking. From what I can see ARC is by default off in podfiles, so it needs to be explicitly set to on to make Toast not leak.
