### PR TITLE
Update UIView+Toast.m

### DIFF
--- a/Toast/Toast/UIView+Toast.m
+++ b/Toast/Toast/UIView+Toast.m
@@ -226,6 +226,7 @@ static const NSString * CSToastActivityViewKey  = @"CSToastActivityViewKey";
 }
 
 - (CGSize)sizeForString:(NSString *)string font:(UIFont *)font constrainedToSize:(CGSize)constrainedSize lineBreakMode:(NSLineBreakMode)lineBreakMode {
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 70000    
     if ([string respondsToSelector:@selector(boundingRectWithSize:options:attributes:context:)]) {
         NSMutableParagraphStyle *paragraphStyle = [[NSMutableParagraphStyle alloc] init];
         paragraphStyle.lineBreakMode = lineBreakMode;
@@ -233,8 +234,11 @@ static const NSString * CSToastActivityViewKey  = @"CSToastActivityViewKey";
         CGRect boundingRect = [string boundingRectWithSize:constrainedSize options:NSStringDrawingUsesLineFragmentOrigin attributes:attributes context:nil];
         return CGSizeMake(ceilf(boundingRect.size.width), ceilf(boundingRect.size.height));
     }
-
+#endif
+#if __IPHONE_OS_VERSION_MAX_ALLOWED <= 70000
     return [string sizeWithFont:font constrainedToSize:constrainedSize lineBreakMode:lineBreakMode];
+#endif
+    return CGSizeZero;
 }
 
 - (UIView *)viewForMessage:(NSString *)message title:(NSString *)title image:(UIImage *)image {


### PR DESCRIPTION
Supress 'sizeWithFont deprecated' warning in iOS >= 7.0
