### PR TITLE
Non-overlapping Toasts

### DIFF
--- a/Toast.podspec
+++ b/Toast.podspec
@@ -2,10 +2,10 @@ Pod::Spec.new do |s|
   s.name         = "Toast"
   s.version      = "2.4"
   s.summary      = "A UIView category that adds Android-style toast notifications to iOS."
-  s.homepage     = "https://github.com/scalessec/Toast"
+  s.homepage     = "https://github.com/Elemida/Toast"
   s.license      = 'MIT'
   s.author       = { "Charles Scalesse" => "scalessec@gmail.com" }
-  s.source       = { :git => "https://github.com/scalessec/Toast.git", :tag => "2.4" }
+  s.source       = { :git => "https://github.com/Elemida/Toast.git", :tag => "2.4" }
   s.platform     = :ios
   s.source_files = 'Toast/Toast'   
   s.framework    = 'QuartzCore'

--- a/Toast/Toast/UIView+Toast.m
+++ b/Toast/Toast/UIView+Toast.m
@@ -52,6 +52,7 @@ static const BOOL CSToastHidesOnTap             = YES;     // excludes activity 
 static const NSString * CSToastTimerKey         = @"CSToastTimerKey";
 static const NSString * CSToastActivityViewKey  = @"CSToastActivityViewKey";
 static const NSString * CSToastTapCallbackKey   = @"CSToastTapCallbackKey";
+static const NSInteger CSToastTagID             = -1685;
 
 // positions
 NSString * const CSToastPositionTop             = @"top";
@@ -112,6 +113,7 @@ NSString * const CSToastPositionBottom          = @"bottom";
 - (void)showToast:(UIView *)toast duration:(NSTimeInterval)duration position:(id)position
       tapCallback:(void(^)(void))tapCallback
 {
+    toast.tag = CSToastTagID;
     toast.center = [self centerPointForPosition:position withToast:toast];
     toast.alpha = 0.0;
     
@@ -121,6 +123,8 @@ NSString * const CSToastPositionBottom          = @"bottom";
         toast.userInteractionEnabled = YES;
         toast.exclusiveTouch = YES;
     }
+    
+    [self pushToastsUp];
     
     [self addSubview:toast];
     
@@ -137,6 +141,23 @@ NSString * const CSToastPositionBottom          = @"bottom";
                      }];
 }
 
+- (void)pushToastUp:(UIView *)toastView {
+    CGFloat height = toastView.frame.size.height;
+    
+    [UIView animateWithDuration:CSToastFadeDuration
+                          delay:0.0
+                        options:(UIViewAnimationOptionCurveEaseOut | UIViewAnimationOptionAllowUserInteraction)
+                     animations:^{
+                         toastView.center = CGPointMake(self.bounds.size.width/2, toastView.frame.origin.y - height);
+                     } completion:nil];
+}
+- (void)pushToastsUp {
+    for (UIView *toastView in self.subviews) {
+        if (toastView.tag == CSToastTagID) {
+            [self pushToastUp:toastView];
+        }
+    }
+}
 
 - (void)hideToast:(UIView *)toast {
     [UIView animateWithDuration:CSToastFadeDuration


### PR DESCRIPTION
If a new toast is displayed before the first has disappeared then the first toast will be moved upwards. This means they will not lay on top of each other.