### PR TITLE
Bug & enhancements

### DIFF
--- a/Toast/Toast/UIView+Toast.m
+++ b/Toast/Toast/UIView+Toast.m
@@ -261,7 +261,7 @@ NSString * const CSToastPositionBottom          = @"bottom";
 
 - (UIView *)viewForMessage:(NSString *)message title:(NSString *)title image:(UIImage *)image {
     // sanity
-    if((message == nil) && (title == nil) && (image == nil)) return nil;
+    if((message == nil || [message length] == 0) && (title == nil || [title length] == 0) && (image == nil)) return nil;
 
     // dynamically build a toast view with any combination of message, title, & image.
     UILabel *messageLabel = nil;

--- a/Toast/Toast/UIView+Toast.m
+++ b/Toast/Toast/UIView+Toast.m
@@ -112,6 +112,9 @@ NSString * const CSToastPositionBottom          = @"bottom";
 - (void)showToast:(UIView *)toast duration:(NSTimeInterval)duration position:(id)position
       tapCallback:(void(^)(void))tapCallback
 {
+    // sanity
+    if (!toast) return;
+    
     toast.center = [self centerPointForPosition:position withToast:toast];
     toast.alpha = 0.0;
     


### PR DESCRIPTION
BUG: showToast `EXC_BAD_ACCESS (code=1, address=0x0) at objc_setAssociatedObject`

Because func viewForMessage may return a nil, if we don't check it, we will get run time error at objc_setAssociatedObject

Enhancements: `viewForMessage` check message and title length
If message or title is @"", the toast view still shows up with no character, it is weird, and should not happen from my perspective. Corret me if you have other scenarios to take into account.

Attention:
This enhancement requires above bug fix, if toast view is nil, then the function should return
