### PR TITLE
Current toast view can be configured to hide upon arrival of new toast

### DIFF
--- a/Toast/Example/CSViewController.m
+++ b/Toast/Example/CSViewController.m
@@ -71,6 +71,10 @@ static NSString * ZOToastDemoCellId     = @"ZOToastDemoCellId";
     [CSToastManager setQueueEnabled:![CSToastManager isQueueEnabled]];
 }
 
+- (void)handleExclusiveToggled {
+    [CSToastManager setExclusive:![CSToastManager isExclusive]];
+}
+
 #pragma mark - UITableViewDelegate & Datasource Methods
 
 - (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView {
@@ -79,7 +83,7 @@ static NSString * ZOToastDemoCellId     = @"ZOToastDemoCellId";
 
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
     if (section == 0) {
-        return 2;
+        return 3;
     } else {
         return 9;
     }
@@ -117,7 +121,7 @@ static NSString * ZOToastDemoCellId     = @"ZOToastDemoCellId";
             cell.textLabel.text = @"Tap to Dismiss";
             [(UISwitch *)cell.accessoryView setOn:[CSToastManager isTapToDismissEnabled]];
             return cell;
-        } else {
+        } else if (indexPath.row == 1) {
             UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:ZOToastSwitchCellId];
             if (cell == nil) {
                 cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:ZOToastSwitchCellId];
@@ -130,6 +134,20 @@ static NSString * ZOToastDemoCellId     = @"ZOToastDemoCellId";
             }
             cell.textLabel.text = @"Queue Toast";
             [(UISwitch *)cell.accessoryView setOn:[CSToastManager isQueueEnabled]];
+            return cell;
+        } else {
+            UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:ZOToastSwitchCellId];
+            if (cell == nil) {
+                cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:ZOToastSwitchCellId];
+                UISwitch *exclusiveSwitch = [[UISwitch alloc] init];
+                exclusiveSwitch.onTintColor = [UIColor orangeColor];
+                [exclusiveSwitch addTarget:self action:@selector(handleExclusiveToggled) forControlEvents:UIControlEventValueChanged];
+                cell.accessoryView = exclusiveSwitch;
+                cell.selectionStyle = UITableViewCellSelectionStyleNone;
+                cell.textLabel.font = [UIFont systemFontOfSize:16.0];
+            }
+            cell.textLabel.text = @"Exclusive Toast";
+            [(UISwitch *)cell.accessoryView setOn:[CSToastManager isExclusive]];
             return cell;
         }
     } else {

--- a/Toast/Toast/UIView+Toast.h
+++ b/Toast/Toast/UIView+Toast.h
@@ -351,6 +351,25 @@ extern const NSString * CSToastPositionBottom;
 + (BOOL)isTapToDismissEnabled;
 
 /**
+ Showing toast exclusively or not. When 'YES', toast view will
+ be hidden upon arrival of new toast, without adding to the queue.
+ Thus there is only one toast showing at a time, the new toast overlaps
+ others completely. When 'NO', toast views can be queued or overlap
+ each other, leaving parts beneath new ones. Default is 'NO'.
+ 
+ @param exclusive
+ */
++ (void)setExclusive:(BOOL)exclusive;
+
+/**
+ Returns `YES` if toasts are shown exclusively, otherwise `NO`.
+ Default is `NO`.
+ 
+ @return BOOL
+ */
++ (BOOL)isExclusive;
+
+/**
  Enables or disables queueing behavior for toast views. When `YES`,
  toast views will appear one after the other. When `NO`, multiple Toast
  views will appear at the same time (potentially overlapping depending


### PR DESCRIPTION
Adding configuration isExclusive to CSToastManager, 

Fix bug: if create different toast quickly, the timer and value for CSToastActiveToastViewKey may mismatch. Modify the time to clear CSToastActiveToastViewKey or generate timer for CSToastTimerKey. Performing outside of animation block instead of complete block.
