### PR TITLE
fix podspec for header import format when using cocoapods

### DIFF
--- a/Toast.podspec
+++ b/Toast.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |s|
   s.author       = { "Charles Scalesse" => "scalessec@gmail.com" }
   s.source       = { :git => "https://github.com/scalessec/Toast.git", :tag => "3.1.0" }
   s.platform     = :ios
-  s.source_files = 'Toast/Toast'   
+  s.source_files = 'Toast/Toast','Toast/Toast.h'   
   s.framework    = 'QuartzCore'
   s.requires_arc = true
 end


### PR DESCRIPTION
I am a Chinese ,my English is not well , so please bear with me。
Thest days , I am working on change from using Carghage to use Cocoapods. And I find some a little bit different when write a "import header" statement.
Take Toast as an example : 
	First, I use Carthage ,so , In my own class file , I can use #import <Toast/Toast.h> statement to import the framework (Of course , I know that use  #import <Toast/UIView+Toast.h>  is the right way , but not everyone obey the rules). In this case , when I change to use Cocoapods , Toast/Toast.h will not be found , Instead，#import <Toast/Toast-umbrella.h> is the recommended way. But in old codes , #import <Toast/Toast.h> is everywhere , so I should find a way to change Carthage to Cocoapods  transparently.
In the end , I find that take Toast.h as public header is good way（ reference AFNetworking）.(Becase if not, Cocoapods default create framework's public header as xxx-umbrella.h).
I think its important to maintain consistency of using a framework no matter use Carthage or Cocoapods.