### PR TITLE
Fix for issue #68 with title and message text alignment

### DIFF
--- a/Toast/UIView+Toast.m
+++ b/Toast/UIView+Toast.m
@@ -257,6 +257,7 @@ static const NSString * CSToastQueueKey             = @"CSToastQueueKey";
         imageRect.size.height = imageView.bounds.size.height;
     }
     
+    CGSize expectedSizeTitle = CGSizeZero;
     if (title != nil) {
         titleLabel = [[UILabel alloc] init];
         titleLabel.numberOfLines = style.titleNumberOfLines;
@@ -269,13 +270,13 @@ static const NSString * CSToastQueueKey             = @"CSToastQueueKey";
         titleLabel.text = title;
         
         // size the title label according to the length of the text
-        CGSize maxSizeTitle = CGSizeMake((self.bounds.size.width * style.maxWidthPercentage) - imageRect.size.width, self.bounds.size.height * style.maxHeightPercentage);
-        CGSize expectedSizeTitle = [titleLabel sizeThatFits:maxSizeTitle];
+        CGSize maxSizeTitle = CGSizeMake((self.bounds.size.width * style.maxWidthPercentage) - imageRect.size.width - 2 * style.horizontalPadding, self.bounds.size.height * style.maxHeightPercentage);
+        expectedSizeTitle = [titleLabel sizeThatFits:maxSizeTitle];
         // UILabel can return a size larger than the max size when the number of lines is 1
         expectedSizeTitle = CGSizeMake(MIN(maxSizeTitle.width, expectedSizeTitle.width), MIN(maxSizeTitle.height, expectedSizeTitle.height));
-        titleLabel.frame = CGRectMake(0.0, 0.0, expectedSizeTitle.width, expectedSizeTitle.height);
     }
     
+    CGSize expectedSizeMessage = CGSizeZero;
     if (message != nil) {
         messageLabel = [[UILabel alloc] init];
         messageLabel.numberOfLines = style.messageNumberOfLines;
@@ -287,16 +288,17 @@ static const NSString * CSToastQueueKey             = @"CSToastQueueKey";
         messageLabel.alpha = 1.0;
         messageLabel.text = message;
         
-        CGSize maxSizeMessage = CGSizeMake((self.bounds.size.width * style.maxWidthPercentage) - imageRect.size.width, self.bounds.size.height * style.maxHeightPercentage);
-        CGSize expectedSizeMessage = [messageLabel sizeThatFits:maxSizeMessage];
+        CGSize maxSizeMessage = CGSizeMake((self.bounds.size.width * style.maxWidthPercentage) - imageRect.size.width - 2 * style.horizontalPadding, self.bounds.size.height * style.maxHeightPercentage);
+        expectedSizeMessage = [messageLabel sizeThatFits:maxSizeMessage];
         // UILabel can return a size larger than the max size when the number of lines is 1
         expectedSizeMessage = CGSizeMake(MIN(maxSizeMessage.width, expectedSizeMessage.width), MIN(maxSizeMessage.height, expectedSizeMessage.height));
-        messageLabel.frame = CGRectMake(0.0, 0.0, expectedSizeMessage.width, expectedSizeMessage.height);
     }
     
     CGRect titleRect = CGRectZero;
     
     if(titleLabel != nil) {
+        // Ensure to set both title and message frames to the same width, so the 'textAlignment' property will have effect:
+        titleLabel.frame = CGRectMake(0.0, 0.0, MAX(expectedSizeTitle.width, expectedSizeMessage.width), expectedSizeTitle.height);
         titleRect.origin.x = imageRect.origin.x + imageRect.size.width + style.horizontalPadding;
         titleRect.origin.y = style.verticalPadding;
         titleRect.size.width = titleLabel.bounds.size.width;
@@ -306,6 +308,8 @@ static const NSString * CSToastQueueKey             = @"CSToastQueueKey";
     CGRect messageRect = CGRectZero;
     
     if(messageLabel != nil) {
+        // Ensure to set both title and message frames to the same width, so the 'textAlignment' property will have effect:
+        messageLabel.frame = CGRectMake(0.0, 0.0, MAX(expectedSizeTitle.width, expectedSizeMessage.width), expectedSizeMessage.height);
         messageRect.origin.x = imageRect.origin.x + imageRect.size.width + style.horizontalPadding;
         messageRect.origin.y = titleRect.origin.y + titleRect.size.height + style.verticalPadding;
         messageRect.size.width = messageLabel.bounds.size.width;


### PR DESCRIPTION
This solves issue https://github.com/scalessec/Toast/issues/68 with title and message alignment:

* The solution it to use the same width for both UILabels. This will be the largest value of the 2 expected widths based on the text content.
* The available width for the UILabel was too large; the `style.horizontalPadding` wasn't respected.

Here is the before (left) and after (right) when using `style.titleAlignment = NSTextAlignmentCenter;`:

![original-hor-padding-10-sbs](https://user-images.githubusercontent.com/2139844/35445960-9460f37c-02b3-11e8-82e4-c3d12a15ce26.png)

It also solves a problem that the UILabel is not resizing when using `horizontalPadding`:

![original-hor-padding-70-sbs](https://user-images.githubusercontent.com/2139844/35446063-dd784c54-02b3-11e8-9bf0-15108b04d51d.png)
 