### PR TITLE
Fix Podspec resource bundle for privacy manifest

### DIFF
--- a/Toast.podspec
+++ b/Toast.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/scalessec/Toast.git", :tag => s.version.to_s }
   s.platform     = :ios
   s.source_files = 'Toast', 'Toast-Framework/Toast.h'
-  s.resources    = ['Toast/Resources/PrivacyInfo.xcprivacy']
+  s.resource_bundles = {'Toast' => ['Toast/Resources/PrivacyInfo.xcprivacy']}
   s.framework    = 'QuartzCore'
   s.requires_arc = true
   s.ios.deployment_target = '12.0'


### PR DESCRIPTION
Change from 'resource' to 'resource_bundle' to prevent library user having conflicting PrivacyInfo.xcprivacy when building.